### PR TITLE
UShapedRecipeSerializer: fix incorrect serialization

### DIFF
--- a/forge/src/main/java/info/u_team/u_team_core/recipeserializer/UShapedRecipeSerializer.java
+++ b/forge/src/main/java/info/u_team/u_team_core/recipeserializer/UShapedRecipeSerializer.java
@@ -80,8 +80,8 @@ public abstract class UShapedRecipeSerializer<T extends ShapedRecipe> implements
 		for (final Ingredient ingredient : recipe.recipeItems) {
 			ingredient.toNetwork(buffer);
 		}
-		buffer.writeBoolean(recipe.showNotification);
 		buffer.writeItem(recipe.result);
+		buffer.writeBoolean(recipe.showNotification);
 	}
 	
 	protected abstract T createRecipe(ResourceLocation location, String group, CraftingBookCategory category, int recipeWidth, int recipeHeight, NonNullList<Ingredient> ingredients, ItemStack output, boolean showNotification);


### PR DESCRIPTION
The order of `result` and `showNotification` is backwards in toNetwork compared to fromNetwork. This fixes the following disconnect when using Useful Backpacks with Open to LAN (and possibly dedicated servers): 
![image](https://user-images.githubusercontent.com/52044242/234987537-4df549e9-8f9f-4df4-8440-1e356fedea07.png)
